### PR TITLE
Make isAwesome public to convert nib-based buttons.

### DIFF
--- a/Control/UIButton+PPiAwesome.h
+++ b/Control/UIButton+PPiAwesome.h
@@ -26,5 +26,6 @@ typedef enum {
 -(void)setButtonIcon:(NSString*)icon;
 -(void)setRadius:(CGFloat)radius;
 -(void)setSeparation:(NSUInteger)separation;
+-(void)setIsAwesome:(BOOL)isAwesome;
 
 @end


### PR DESCRIPTION
@pepibumur I didn't know if this was intentional or not; but it would be really helpful if the setIsAwesome: was made public so buttons that were awoken from nib can be converted to awesome buttons.  Take it or leave it.  Great library btw.  I'll be using it for one of my projects.  Do you know if there's any repercussions from using objc_setAssociatedObject?  Do you know if Apple will have a problem with this in the review process?
