### PR TITLE
override enabled right way.

### DIFF
--- a/Control/UIButton+PPiAwesome.m
+++ b/Control/UIButton+PPiAwesome.m
@@ -255,12 +255,20 @@ static char separationKey;
 }
 
 // override enabled
--(void)setEnabled:(BOOL)enabled {
-    [super setEnabled:enabled];
+-(void)swizzle_setEnabled:(BOOL)enabled {
+    [self swizzle_setEnabled:enabled];
     if (enabled) {
         [self updateButtonFormatForUIControlState:UIControlStateNormal];
     } else {
         [self updateButtonFormatForUIControlState:UIControlStateDisabled];
     }
+}
+
++ (void)load {
+    Method original, swizzle;
+    
+    original = class_getInstanceMethod(self, @selector(setEnabled:));
+    swizzle = class_getInstanceMethod(self, @selector(swizzle_setEnabled:));
+    method_exchangeImplementations(original, swizzle);
 }
 @end


### PR DESCRIPTION
It's a very import bug.
If a category overrides a method that exists in the category's class, there is no way to invoke the original implementation.
So it's no way to setEnabled.
